### PR TITLE
Switched from argparse to docopt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ setup.cfg
 logging.yml
 errors.log*
 debug.log*
+*.swp

--- a/README.md
+++ b/README.md
@@ -23,14 +23,20 @@ pip install -r requirements.txt
 
 ```bash
 $> python kort2osm.py --help
-usage: kort2osm.py [-h] [-d] [-q] [-v] [-c COUNT]
+kort-to-osm
 
-optional arguments:
-  -h, --help                show this help message and exit
-  -d, --dry                 do not actually make changes, only a dry run
-  -q, --quiet               run quietly without any output
-  -v, --verbose             show more verbose output
-  -c COUNT, --count COUNT   count of fixes to run through from kort to OSM
+Usage:
+  kort2osm.py [-d] [-q] [-v] [-c COUNT]
+  kort2osm.py -h | --help
+  kort2osm.py --version
+
+Options:
+  -h, --help               Show this help message and exit.
+  -d, --dry                Do not actually make changes, only a dry run
+  -q, --quiet              Run quietly, without any output.
+  -v, --verbose            Show more verbose output.
+  -c COUNT, --count=COUNT  Count of fixes to run through from kort to OSM.
+  --version                Show the version and exit.
 ```
 
 Per default, the script runs only a single change from Kort to OSM.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ osmapi==0.2.23
 flake8==2.1.0
 pyaml==13.12.0
 httmock==1.0.7
+docopt==0.6.1


### PR DESCRIPTION
In case you're interested, this PR replaces the builtin argparse module with the external docopt module.

http://docopt.org/
https://github.com/docopt/docopt

It makes it much simpler to create command line interfaces. You just edit the documentation in the module docstring, and the interface automatically adjusts.

Example (using pdb):

```
$ python kort2osm.py -d -v -c 10
> /home/danilo/Projects/kort-to-osm/kort2osm.py(56)<module>()
(Pdb) arguments
{'--count': '10',
 '--dry': True,
 '--help': False,
 '--quiet': False,
 '--verbose': True,
 '--version': False}
```

I couldn't really test it because I don't want to actually commit something to OSM, but the CLI interface should be equivalent.
